### PR TITLE
Adiciona usuário e grupo para garantir UID/GID dono de arquivos gerados pelo XC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,12 @@ RUN cd /src \
 FROM python:3.8-buster
 MAINTAINER scielo-dev@googlegroups.com
 
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+
+RUN groupadd -g ${GROUP_ID} prodtools \
+    && useradd -u ${USER_ID} -g ${GROUP_ID} prodtools
+
 COPY --from=build /deps/* /deps/
 COPY requirements.txt .
 
@@ -22,5 +28,9 @@ RUN apt-get update -qq \
     && rm -rf /deps
 
 WORKDIR /app/xml
+
+RUN chown -R ${USER_ID}:${GROUP_ID} /app
+
+USER prodtools
 
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona usuário e grupo com respectivos UID e GID no Dockerfile.
Isto é realizado para garantir que arquivos gerados pelo XC tenham como proprietário o usuário e grupo indicados.

#### Onde a revisão poderia começar?
Por commits.

#### Como este poderia ser testado manualmente?
- Fazer build do repositório;
- Obter insumos para scieloserverxc e montá-los em volumes no container;
- Rodar scieloserverxc ARQUIVO_INI (um dos insumos necessários);
- Verificar quem é o proprietário dos arquivos gerados.


### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
Indique uma issue ao qual o pull request faz relacionamento.

### Referências
N/A

