### PR TITLE
Remove --no-index permitindo a busca por pacotes no PyPi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN mkdir -p /app/markup
 RUN apt-get update -qq \
     && apt-get install -qq -y libxml2 libxslt-dev libjpeg-dev tk lib32z1 lib32z1-dev \
     && pip install --no-cache-dir -r requirements.txt \
-    && pip install --no-index --find-links=file:///deps -U SciELO_Production_Tools \
+    && pip install --no-cache-dir --find-links=file:///deps -U SciELO_Production_Tools \
     && rm requirements.txt \
     && rm -rf /deps
 


### PR DESCRIPTION
#### O que esse PR faz?
Remove `--no-index` de modo a permitir que o `pip` procure por pacotes no PyPi.

#### Onde a revisão poderia começar?
Revisar o único commit existente.

#### Como este poderia ser testado manualmente?
1. Baixar repositório
2. Construir imagem:  `docker build --tag prodtools:text ./`

#### Algum cenário de contexto que queira dar?
A remoção do termo `--no-index` se fez necessária por causa da recente atualização do `pip` para a versão `20.2`. Essa atualização fez com que o `pip` não fosse capaz de enxergar localmente (`--find-links`) uma das dependências (`picles.plumber`) do pacote `packtools`. Então, permitindo a busca no `PyPi` resolve o problema.

### Screenshots
N/A

#### Quais são tickets relevantes?
#10 

### Referências
Indique as referências utilizadas para a elaboração do pull request.

