### PR TITLE
[FASE 3] No relatório indica se o pacote foi disponilizado para o SPF

### DIFF
--- a/prodtools/processing/pkg_processors.py
+++ b/prodtools/processing/pkg_processors.py
@@ -369,14 +369,17 @@ class ArticlesConversion(object):
     def spf_message(self):
         if not self.sps_pkg_info:
             return ""
-        ftp = ""
+        result = False
         if self.sps_pkg_info.get("server"):
-            ftp = _("(FTP: {} | User: {})").format(
+            result = _("FTP: {} | User: {}").format(
                     self.sps_pkg_info.get("server"),
                     self.sps_pkg_info.get("user", ''))
+        elif self.sps_pkg_info.get("file"):
+            result = os.path.isfile(self.sps_pkg_info.get("file"))
+
         return html_reports.p_message(
-                _("[INFO] {} is available for SPF {}").format(
-                    self.sps_pkg_info.get("file"), ftp)
+                _("[INFO] {} is available for SPF ({})").format(
+                    self.sps_pkg_info.get("file"), result)
             )
 
 

--- a/prodtools/utils/exporter.py
+++ b/prodtools/utils/exporter.py
@@ -76,7 +76,12 @@ class Exporter(object):
             final_file_path = self._preppend_time_to_destination_filename(
                 dest_path, zip_file_path
             )
+            exp_logger.info("Exporter: move %s to %s", zip_file_path, final_file_path)
             shutil.move(zip_file_path, final_file_path)
+            if os.path.isfile(final_file_path):
+                exp_logger.info("Exporter: %s created", final_file_path)
+            else:
+                exp_logger.error("Exporter: %s not found", final_file_path)
 
             if not destination_path and ftp_configuration:
                 server, user, password, remote_path = ftp_configuration


### PR DESCRIPTION
#### O que esse PR faz?
No relatório indica se o pacote foi disponilizado para o SPF

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
1. Ter o ambiente preparado para o XC que exige ter bases title, issue, cisis, e configuração do KG_destination=<pasta destino do pacote para o SPF>.
2. Executar o XC com qualquer pacote
3. Observar no relatório a mensagem, acrescida de (`True`) ou (`False`).

<img width="652" alt="Captura de Tela 2020-08-12 às 18 06 39" src="https://user-images.githubusercontent.com/505143/90189349-630dc800-dd93-11ea-8e0d-44f71aef8b2f.png">(`True`) ou (`False`)

#### Algum cenário de contexto que queira dar?
O relatório informava o caminho do arquivo, mas não necessariamente se existia ou não. Talvez isso explicite porquê alguns pacotes não estão disponíveis apesar de estar ok no relatório.
Uma outra questão que talvez estivesse interferindo é que o `crontab` ainda continha o nosso teste. Havia a execução do XC via crontab e também pelo systemctl. Comentei o do crontab.

### Screenshots
n/a

#### Quais são tickets relevantes?
#13

### Referências
n/a
