### PR TITLE
Verifica se contrib-id tem texto para, então, verificar se existe URI

### DIFF
--- a/prodtools/processing/sps_pkgmaker.py
+++ b/prodtools/processing/sps_pkgmaker.py
@@ -90,7 +90,7 @@ class SPSXMLContent(xml_utils.SuitableXML):
             xpath = ".//contrib-id[@contrib-id-type='{}']".format(
                 contrib_id_type)
             for contrib_id in self.xml.findall(xpath):
-                if uri in contrib_id.text:
+                if contrib_id.text and uri in contrib_id.text:
                     contrib_id.text = contrib_id.text.replace(uri, "")
 
     def remove_attributes(self):

--- a/tests/test_sps_pkgmaker.py
+++ b/tests/test_sps_pkgmaker.py
@@ -82,6 +82,33 @@ class TestSPSXMLContent(TestCase):
              for contrib_id in obj.xml.findall(".//contrib-id")]
         )
 
+    def test_remove_uri_off_contrib_id_without_contrib_id(self):
+        text = """<contrib-group>
+        <contrib contrib-type="author">
+            <contrib-id contrib-id-type="orcid"/>
+            <name>
+                <surname>Einstein</surname>
+                <given-names>Albert</given-names>
+            </name>
+        </contrib>
+        <contrib contrib-type="author">
+            <contrib-id contrib-id-type="lattes">https://lattes.cnpq.br/4760273612238540</contrib-id>
+            <name>
+                <surname>Meneghini</surname>
+                <given-names>Rogerio</given-names>
+            </name>
+        </contrib></contrib-group>"""
+        obj = sps_pkgmaker.SPSXMLContent(text)
+        obj.remove_uri_off_contrib_id()
+        self.assertEqual(
+            ['4760273612238540'],
+            [
+                contrib_id.text
+                for contrib_id in obj.xml.findall(".//contrib-id")
+                if contrib_id.text
+            ]
+        )
+
 
 class TestBrokenRef(TestCase):
 


### PR DESCRIPTION
#### O que esse PR faz?
Corrige erro de remoção de URLs no `contrib-id` durante a execução do XPM.

#### Onde a revisão poderia começar?
Em `prodtools/processing/sps_pkgmaker.py`

#### Como este poderia ser testado manualmente?
1. Execute o XPM com um XML que contém um autor com `contrib-id` sem valor na tag. Há um exemplo em `tests/test_sps_pkgmaker.py`, L88, ou com o próprio pacote SPS `0021-7557-jped-96-04.zip`
2. A execução deve acontecer sem interrupção.

#### Algum cenário de contexto que queira dar?
Mais detalhes no issue.

### Screenshots
Relatório com aviso de ausência do contrib-id após correção:

<img width="1212" alt="Screen Shot 2020-08-21 at 15 49 10" src="https://user-images.githubusercontent.com/18053487/90924608-2c086980-e3c6-11ea-8c56-a7c70e0f6a75.png">

#### Quais são tickets relevantes?
#17

### Referências
.