### PR TITLE
Reduz a restrição / bloqueio de DOI duplicado pois há documentos que …

### DIFF
--- a/prodtools/data/merged.py
+++ b/prodtools/data/merged.py
@@ -45,7 +45,13 @@ class GroupedDocuments(object):
         grouped_docs.values: article.Article
         """
         self.grouped_docs = grouped_docs
-        self.ERROR_LEVEL_FOR_UNIQUE_VALUES = {'order': validation_status.STATUS_BLOCKING_ERROR, 'doi': validation_status.STATUS_BLOCKING_ERROR, 'elocation id': validation_status.STATUS_BLOCKING_ERROR, 'fpage-lpage-seq-elocation-id': validation_status.STATUS_ERROR}
+
+        self.ERROR_LEVEL_FOR_UNIQUE_VALUES = {
+            'order': validation_status.STATUS_BLOCKING_ERROR,
+            'doi': validation_status.STATUS_FATAL_ERROR,
+            'elocation id': validation_status.STATUS_BLOCKING_ERROR,
+            'fpage-lpage-seq-elocation-id': validation_status.STATUS_ERROR,
+        }
         if not is_db_generation:
             self.ERROR_LEVEL_FOR_UNIQUE_VALUES['order'] = validation_status.STATUS_WARNING
         self.IGNORE_NONE = ['journal-id (nlm-ta)', 'e-ISSN', 'print ISSN', ]


### PR DESCRIPTION
…estão realmente com DOI errado

#### O que esse PR faz?
Não bloqueia mais se DOI está duplicado, pois há casos que o DOI está incorreto no original.

#### Onde a revisão poderia começar?
.
#### Como este poderia ser testado manualmente?
.
#### Algum cenário de contexto que queira dar?
xc.hml

### Screenshots
.
#### Quais são tickets relevantes?
.
### Referências
.
