### PR TITLE
Melhorar a recuperação e o registro de pid v3 no pid_manager

### DIFF
--- a/prodtools/data/kernel_document.py
+++ b/prodtools/data/kernel_document.py
@@ -179,7 +179,7 @@ def add_article_id_to_received_documents(
             # se v3 não está no presente no XML, consulta no pid manager pelo
             # previous_pid ou pid_v2 ou gera pid v3
             pid_v3 = (
-                pid_manager.get_pid_v3(article.registered_aop_pid)
+                pid_manager.get_pid_v3(prev_pid)
                 or pid_manager.get_pid_v3(pid_v2)
                 or scielo_id_gen.generate_scielo_pid()
             )

--- a/prodtools/data/kernel_document.py
+++ b/prodtools/data/kernel_document.py
@@ -120,8 +120,15 @@ def add_article_id_to_received_documents(
     for xml_name, article in received_docs.items():
         pids_to_append_in_xml = []
 
-        # Obtém v2 e v3 do XML
+        # Obtém v2 do XML
         pid_v2 = article.get_scielo_pid("v2")
+        if pid_v2 is None:
+            # se v2 não está presente no XML, gerar a partir dos metadados
+            pid_v2 = get_scielo_pid_v2(issn_id, year_and_order, article.order)
+            # anotar para ser inserido no XML
+            pids_to_append_in_xml.append((pid_v2, "scielo-v2"))
+
+        # Obtém v3 do XML
         pid_v3 = article.get_scielo_pid("v3")
 
         # Obtém previous do XML
@@ -142,12 +149,6 @@ def add_article_id_to_received_documents(
                 pid_manager.register(pid_v2, pid_v3)
 
             continue
-
-        if pid_v2 is None:
-            # se v2 não está presente no XML, gerar a partir dos metadados
-            pid_v2 = get_scielo_pid_v2(issn_id, year_and_order, article.order)
-            # anotar para ser inserido no XML
-            pids_to_append_in_xml.append((pid_v2, "scielo-v2"))
 
         if pid_v3 is None:
             # se v3 não está no presente no XML, consulta no pid manager pelo

--- a/prodtools/data/kernel_document.py
+++ b/prodtools/data/kernel_document.py
@@ -124,9 +124,16 @@ def add_article_id_to_received_documents(
         pid_v2 = article.get_scielo_pid("v2")
         pid_v3 = article.get_scielo_pid("v3")
 
-        # Atualiza `article.registered_aop_pid` com previous pid registrado
-        # na base ahead do artigo
-        update_article_with_aop_status(article)
+        # Obtém previous do XML
+        prev_pid = article.previous_article_pid
+        if not prev_pid:
+            # Não há previous do XML
+            # Obtém previous_pid registrado na base ahead do artigo
+            update_article_with_aop_status(article)
+            # acessa previous_pid com `article.registered_aop_pid`
+            prev_pid = article.registered_aop_pid
+            if prev_pid:
+                pids_to_append_in_xml.append((prev_pid, "previous-pid"))
 
         if pid_v2 and pid_v3:
             exists_in_database = pid_manager.pids_already_registered(pid_v2, pid_v3)

--- a/prodtools/data/kernel_document.py
+++ b/prodtools/data/kernel_document.py
@@ -163,14 +163,6 @@ def add_article_id_to_received_documents(
             if prev_pid:
                 pids_to_append_in_xml.append((prev_pid, "previous-pid"))
 
-        if pid_v3:
-            # se pid_v3 estiver no XML, deve prevalecer
-            register_pids(pid_manager, pid_v3, prev_pid, pid_v2)
-
-            # atualizar o XML com pids_to_append_in_xml
-            update_xml_file(file_path, pids_to_append_in_xml)
-            continue
-
         if pid_v3 is None:
             # se v3 não está no presente no XML, consulta no pid manager pelo
             # previous_pid ou pid_v2 ou gera pid v3
@@ -180,11 +172,13 @@ def add_article_id_to_received_documents(
                 scielo_id_gen.generate_scielo_pid()
             )
             article.registered_scielo_id = pid_v3
-
-            register_pids(pid_manager, pid_v3, prev_pid, pid_v2)
             # anotar para ser inserido no XML
             pids_to_append_in_xml.append((pid_v3, "scielo-v3"))
 
+        # registra no pid_manager os pares (v2,v3) não registrados
+        register_pids(pid_manager, pid_v3, prev_pid, pid_v2)
+
+        # atualizar o XML com pids_to_append_in_xml
         update_xml_file(file_path, pids_to_append_in_xml)
 
 

--- a/prodtools/data/kernel_document.py
+++ b/prodtools/data/kernel_document.py
@@ -166,11 +166,12 @@ def add_article_id_to_received_documents(
         if pid_v3 is None:
             # se v3 não está no presente no XML, consulta no pid manager pelo
             # previous_pid ou pid_v2 ou gera pid v3
+
             pid_v3 = (
-                pid_manager.get_pid_v3(prev_pid) or
-                pid_manager.get_pid_v3(pid_v2) or
+                pid_manager.get_most_recent_pid_v3(prev_pid, pid_v2) or
                 scielo_id_gen.generate_scielo_pid()
             )
+
             article.registered_scielo_id = pid_v3
             # anotar para ser inserido no XML
             pids_to_append_in_xml.append((pid_v3, "scielo-v3"))

--- a/prodtools/data/kernel_document.py
+++ b/prodtools/data/kernel_document.py
@@ -175,9 +175,9 @@ def add_article_id_to_received_documents(
             # se v3 não está no presente no XML, consulta no pid manager pelo
             # previous_pid ou pid_v2 ou gera pid v3
             pid_v3 = (
-                pid_manager.get_pid_v3(prev_pid)
-                or pid_manager.get_pid_v3(pid_v2)
-                or scielo_id_gen.generate_scielo_pid()
+                pid_manager.get_pid_v3(prev_pid) or
+                pid_manager.get_pid_v3(pid_v2) or
+                scielo_id_gen.generate_scielo_pid()
             )
             article.registered_scielo_id = pid_v3
 

--- a/prodtools/data/kernel_document.py
+++ b/prodtools/data/kernel_document.py
@@ -142,12 +142,16 @@ def add_article_id_to_received_documents(
             if prev_pid:
                 pids_to_append_in_xml.append((prev_pid, "previous-pid"))
 
-        if pid_v2 and pid_v3:
-            exists_in_database = pid_manager.pids_already_registered(pid_v2, pid_v3)
-
-            if not exists_in_database:
-                pid_manager.register(pid_v2, pid_v3)
-
+        if pid_v3:
+            # se pid_v3 estiver no XML, deve prevalecer
+            for v2 in (prev_pid, pid_v2):
+                if not v2:
+                    continue
+                found_in_db = pid_manager.pids_already_registered(v2, pid_v3)
+                if not found_in_db:
+                    pid_manager.register(v2, pid_v3)
+            # atualizar o XML com pids_to_append_in_xml
+            
             continue
 
         if pid_v3 is None:

--- a/prodtools/db/pid_versions.py
+++ b/prodtools/db/pid_versions.py
@@ -62,6 +62,26 @@ class PIDVersionsManager:
         if pid_register:
             return pid_register.v3
 
+    def get_records(self, v2):
+        if not v2:
+            return
+        self.session = self.Session()
+        return self.session.query(PidVersion).filter_by(v2=v2).all()
+
+    def get_most_recent_pid_v3(self, prev_pid, pid_v2):
+        prev_records = self.get_records(prev_pid) or []
+        v2_records = self.get_records(pid_v2) or []
+        v3_items = set([record.v3 for record in prev_records + v2_records])
+
+        if len(v3_items) == 1:
+            return v3_items.pop()
+        elif len(v3_items) > 1:
+            # encontrou v3 repetidos para o mesmo documento
+            # considerar o mais recente record.id é o maior
+            return sorted(
+                        [(record.id, record.v3)
+                         for record in prev_records + v2_records])[-1][1]
+
     def pids_already_registered(self, v2, v3):
         """Verifica se a chave composta (v2 e v3) existe no banco de dadoss"""
         self.session = self.Session()

--- a/prodtools/db/pid_versions.py
+++ b/prodtools/db/pid_versions.py
@@ -55,6 +55,8 @@ class PIDVersionsManager:
             return True
 
     def get_pid_v3(self, v2):
+        if not v2:
+            return
         self.session = self.Session()
         pid_register = self.session.query(PidVersion).filter_by(v2=v2).first()
         if pid_register:

--- a/tests/test_kernel_document.py
+++ b/tests/test_kernel_document.py
@@ -57,9 +57,9 @@ class TestKernelDocumentAddArticleIdToReceivedDocuments(unittest.TestCase):
             except IOError:
                 pass
 
-    def _return_scielo_pid_v3_if_aop_pid_match(self, pid):
+    def _return_scielo_pid_v3_if_aop_pid_match(self, prev_pid, pid):
         """Representa a busca pelo PID v3 a partir do PID v2"""
-        if pid == "AOPPID":
+        if prev_pid == "AOPPID":
             return "pid-v3-registrado-anteriormente-para-documento-aop"
         return "brzWFrVFdpYMXdpvq7dDJBQ"
 
@@ -84,7 +84,7 @@ class TestKernelDocumentAddArticleIdToReceivedDocuments(unittest.TestCase):
         year_and_order = "20173"
 
         mock_pid_manager = Mock()
-        mock_pid_manager.get_pid_v3.return_value = None
+        mock_pid_manager.get_most_recent_pid_v3.return_value = None
 
         kernel_document.scielo_id_gen.generate_scielo_pid = Mock(return_value="xxxxxx")
         kernel_document.add_article_id_to_received_documents(
@@ -113,7 +113,7 @@ class TestKernelDocumentAddArticleIdToReceivedDocuments(unittest.TestCase):
             article.registered_aop_pid = "AOPPID"
 
         mock_pid_manager = Mock()
-        mock_pid_manager.get_pid_v3 = self._return_scielo_pid_v3_if_aop_pid_match
+        mock_pid_manager.get_most_recent_pid_v3 = self._return_scielo_pid_v3_if_aop_pid_match
 
         kernel_document.add_article_id_to_received_documents(
             pid_manager=mock_pid_manager,

--- a/tests/test_kernel_document.py
+++ b/tests/test_kernel_document.py
@@ -12,14 +12,15 @@ from prodtools.data import kernel_document
 
 
 class MockArticle:
-    def __init__(self, pid_v3, pid_v2):
+    def __init__(self, pid_v3, pid_v2, db_prev_pid=None, prev_pid=None):
         # este atributo não existe no Article real
         self._scielo_pid = pid_v2
 
         # estes atributos existem no Article real
         self.scielo_id = pid_v3
         self.registered_scielo_id = None
-        self.registered_aop_pid = None
+        self.registered_aop_pid = db_prev_pid
+        self.previous_article_pid = prev_pid
         self.order = "12345"
 
     def get_scielo_pid(self, name):
@@ -124,7 +125,7 @@ class TestKernelDocumentAddArticleIdToReceivedDocuments(unittest.TestCase):
             update_article_with_aop_status=_update_article_with_aop_pid,
         )
 
-        mock_pid_manager.register.assert_called_with(
+        mock_pid_manager.pids_already_registered.assert_called_with(
             "S9876-34562017000312345",
             "pid-v3-registrado-anteriormente-para-documento-aop",
         )
@@ -145,7 +146,7 @@ class TestKernelDocumentAddArticleIdToReceivedDocuments(unittest.TestCase):
             update_article_with_aop_status=lambda _: _,
         )
 
-        self.assertTrue(mock_pid_manager.register.called)
+        self.assertTrue(mock_pid_manager.pids_already_registered.called)
 
     def test_add_pids_to_etree_should_return_none_if_etree_is_not_valid(self):
         self.assertIsNone(kernel_document.add_article_id_to_etree(None, []))


### PR DESCRIPTION
#### O que esse PR faz?
Melhorar a recuperação e o registro de pid v3 no pid_manager, evitando que crie novos pids para documentos anteriormente já registrados.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
executando o xml converter.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#27

### Referências
n/a
