### PR TITLE
Apresentar no relatório autores como anônimos (ocorre em pareceres)

### DIFF
--- a/prodtools/validations/article_data_reports.py
+++ b/prodtools/validations/article_data_reports.py
@@ -67,7 +67,10 @@ def display_author(author):
             if value:
                 texts.append(html_reports.tag('span', value, label))
     else:
-        texts.append(html_reports.tag('span', author.collab, 'collab'))
+        try:
+            texts.append(html_reports.tag('span', author.collab, 'collab'))
+        except AttributeError:
+            texts.append(html_reports.tag('span', author.fullname, 'fullname'))
     return ", ".join([text for text in texts if text])
 
 


### PR DESCRIPTION
#### O que esse PR faz?
Apresentar no relatório autores como anônimos (ocorre em pareceres)

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Converter documento com 

```xml
<article-meta>
			
			<contrib-group>
				<contrib contrib-type="author">
					<anonymous/>
				</contrib>
			</contrib-group>
</article-meta>
```
#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/prodtools/xc.py", line 172, in convert_package
    scilista_items, xc_status, mail_info = self.proc.convert_package(package)
  File "/usr/local/lib/python3.8/site-packages/prodtools/processing/pkg_processors.py", line 453, in convert_package
    registered_issue_data, pkg_eval_result = self.evaluate_package(pkg)
  File "/usr/local/lib/python3.8/site-packages/prodtools/processing/pkg_processors.py", line 436, in evaluate_package
    pkg_eval_result = evaluator.evaluate()
  File "/usr/local/lib/python3.8/site-packages/prodtools/validations/pkg_evaluation.py", line 76, in evaluate
    individual_validations_report=self.pkg_validations_reports.detailed_report,
  File "/usr/local/lib/python3.8/site-packages/prodtools/validations/pkg_articles_validations.py", line 64, in detailed_report
    values.append(a_validations.article_display_report.table_of_contents)
  File "/usr/local/lib/python3.8/site-packages/prodtools/validations/article_data_reports.py", line 563, in table_of_contents
    r += self.table_of_contents_data
  File "/usr/local/lib/python3.8/site-packages/prodtools/validations/article_data_reports.py", line 556, in table_of_contents_data
    return display_article_data_in_toc(self.article)
  File "/usr/local/lib/python3.8/site-packages/prodtools/validations/article_data_reports.py", line 720, in display_article_data_in_toc
    r += display_article_metadata(_article, '; ')
  File "/usr/local/lib/python3.8/site-packages/prodtools/validations/article_data_reports.py", line 702, in display_article_metadata
    'p', display_authors(_article.article_contrib_items, sep)),
  File "/usr/local/lib/python3.8/site-packages/prodtools/validations/article_data_reports.py", line 75, in display_authors
    return sep.join([display_author(item) for item in authors_list])
  File "/usr/local/lib/python3.8/site-packages/prodtools/validations/article_data_reports.py", line 75, in <listcomp>
    return sep.join([display_author(item) for item in authors_list])
  File "/usr/local/lib/python3.8/site-packages/prodtools/validations/article_data_reports.py", line 70, in display_author
    texts.append(html_reports.tag('span', author.collab, 'collab'))
AttributeError: 'AnonymousAuthor' object has no attribute 'collab'

```

#### Quais são tickets relevantes?
n/a

### Referências
n/a
