### PR TITLE
Considera que related-article de pareceres pode não ter `@id`

### DIFF
--- a/prodtools/data/article.py
+++ b/prodtools/data/article.py
@@ -779,7 +779,7 @@ class ArticleXML(object):
                 if item['ext-link-type'] == 'scielo-pid':
                     item['ext-link-type'] = 'pid'
                 item['id'] = rel.attrib.get('id')
-                if item['related-article-type'] not in attributes.related_articles_type:
+                if item['id'] and item['related-article-type'] not in attributes.related_articles_type:
                     item['id'] = ''.join([c for c in item['id'] if c.isdigit()])
                 item['xml'] = tostring(rel)
                 r.append(item)

--- a/prodtools/validations/article_data_reports.py
+++ b/prodtools/validations/article_data_reports.py
@@ -67,7 +67,10 @@ def display_author(author):
             if value:
                 texts.append(html_reports.tag('span', value, label))
     else:
-        texts.append(html_reports.tag('span', author.collab, 'collab'))
+        try:
+            texts.append(html_reports.tag('span', author.collab, 'collab'))
+        except AttributeError:
+            texts.append(html_reports.tag('span', author.fullname, 'fullname'))
     return ", ".join([text for text in texts if text])
 
 


### PR DESCRIPTION
#### O que esse PR faz?
Considera que related-article de pareceres pode não ter `@id`

#### Onde a revisão poderia começar?
por commits, a partir de b47ce18694d602d303778e5a65c154f4ab962f02

#### Como este poderia ser testado manualmente?
convertendo um documento com

```xml
<related-article related-article-type="peer-reviewed-material" ext-link-type="doi" xlink:href="10.1590/fst.54722"></related-article>
```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
````
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/prodtools/xc.py", line 172, in convert_package
    scilista_items, xc_status, mail_info = self.proc.convert_package(package)
  File "/usr/local/lib/python3.8/site-packages/prodtools/processing/pkg_processors.py", line 453, in convert_package
    registered_issue_data, pkg_eval_result = self.evaluate_package(pkg)
  File "/usr/local/lib/python3.8/site-packages/prodtools/processing/pkg_processors.py", line 432, in evaluate_package
    evaluator = PackageEvaluator(
  File "/usr/local/lib/python3.8/site-packages/prodtools/validations/pkg_evaluation.py", line 28, in __init__
    self.pkg_validations_reports = PkgArticlesValidationsReports(
  File "/usr/local/lib/python3.8/site-packages/prodtools/validations/pkg_articles_validations.py", line 20, in __init__
    self.pkg_articles_validations = pkg_validator.validate_package()
  File "/usr/local/lib/python3.8/site-packages/prodtools/validations/article_validations.py", line 260, in validate_package
    results[name] = self.validate_package_item(
  File "/usr/local/lib/python3.8/site-packages/prodtools/validations/article_validations.py", line 275, in validate_package_item
    artval.xml_content_validations, artval.article_display_report = self.xml_content_validator.validate(article, outputs, pkgfiles)
  File "/usr/local/lib/python3.8/site-packages/prodtools/validations/article_validations.py", line 226, in validate
    content.append(article_validation_report.validations(display_all_message_types=False))
  File "/usr/local/lib/python3.8/site-packages/prodtools/validations/article_data_reports.py", line 622, in validations
    items, performance = self.article_validation.validations
  File "/usr/local/lib/python3.8/site-packages/prodtools/validations/article_content_validations.py", line 219, in validations
    self.related_articles,
  File "/usr/local/lib/python3.8/site-packages/prodtools/validations/article_content_validations.py", line 393, in related_articles
    for related_article in self.article.related_articles:
  File "/usr/local/lib/python3.8/site-packages/prodtools/data/article.py", line 783, in related_articles
    item['id'] = ''.join([c for c in item['id'] if c.isdigit()])
TypeError: 'NoneType' object is not iterable
````
#### Quais são tickets relevantes?
n/a

### Referências
n/a
